### PR TITLE
Use tf.data for reading datasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+logs*
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Original repository can be found in [bmild/nerf](https://github.com/bmild/nerf).
 
 Neural Radiance Fields (NeRF) is a method for synthesizing novel views of complex scenes, by optimizing an underlying continuous volumetric scene function using a sparse set of input views. Views are synthesized by querying 5D coordinates (spatial location (*x*, *y*, *z*) and viewing direction (*θ*, *ϕ*)) along camera rays and using classic volume rendering techniques to project the output colors and densities into an image.
 
-This implementation tries to be as close as possible to the original source, bringing some code optimizations and using the flexibility and native multi device (GPUs and TPUs) support JAX offers.
+This implementation tries to be as close as possible to the original source, bringing some code optimizations and using the flexibility and native multi device (GPUs and TPUs) support in JAX.
 
 Most of the comments are from the original work, which are very helpful for understanding the model steps.
 
@@ -19,18 +19,18 @@ Most of the comments are from the original work, which are very helpful for unde
 Install `jax` and `jaxlib` according to your [platform configuration](https://github.com/google/jax#installation). Then, install the necessary dependencies with:
 
 ```
-pip install clu imageio imageio-ffmpeg flax ml_collections pandas tensorboard tensorflow
+pip install clu flax imageio imageio-ffmpeg ml_collections pandas tensorboard tensorflow>=2.4 tqdm
 ```
 
 ## Data
 
 There are three subsets of data used in the original publication that can be downloaded from [nerf_data](https://drive.google.com/drive/folders/128yBriW1IG_3NJ5Rp7APSTZsJqdJdfc1):
-- [Blender](https://drive.google.com/drive/folders/1JDdLGDruGNXWnM1eqY1FNL9PlStjaKWi) aka nerf_synthetic (NeRF authors)
-- [DeepVoxels](https://drive.google.com/open?id=1lUvJWB6oFtT8EQ_NzBrXnmi25BufxRfl) (Vincent Sitzmann)
-- [LLFF](https://drive.google.com/drive/folders/14boI-o5hGO9srnWaaogTU5_ji7wkX2S7) (NeRF authors)
+- [Blender](https://drive.google.com/drive/folders/1JDdLGDruGNXWnM1eqY1FNL9PlStjaKWi) from NeRF authors (`nerf_synthetic.zip`)
+- [DeepVoxels](https://drive.google.com/open?id=1lUvJWB6oFtT8EQ_NzBrXnmi25BufxRfl) from Vincent Sitzmann (`nerf_real_360.zip`)
+- [LLFF](https://drive.google.com/drive/folders/14boI-o5hGO9srnWaaogTU5_ji7wkX2S7) from NeRF authors (`nerf_llff_data.zip`)
 
 In addition, there is:
-- [nerf_example_data](https://people.eecs.berkeley.edu/~bmild/nerf/nerf_example_data.zip) is limited to the `lego` (from Blender) and `fern` (from LLFF) scenes
+- [nerf_example_data](https://drive.google.com/open?id=1xzockqgkO-H3RCGfkZvIZNjOnk3l7AcT) is limited to the `lego` (from Blender) and `fern` (from LLFF) scenes
 - [tiny_nerf_data](https://people.eecs.berkeley.edu/~bmild/nerf/tiny_nerf_data.npz) is a low resolution `lego` used in the simplified notebook example
 
 ## How to run
@@ -58,108 +58,89 @@ python main.py \
     --config.i_print=250
 ```
 
+__NOTE__: check and understand the effect of default parameters in `configs/default.py` to avoid confusion when passing arguments to the model.
+
 ## Examples
 
-All these examples were run on an NVIDIA RTX 2080 Ti with commit [e81d608](https://github.com/myagues/flax_nerf/tree/e81d608128d92c8d15fd17c21834a5e47c185359):
+All examples were run on an NVIDIA RTX 2080Ti. Examples prior to deterministic datasets are available in [e81d608](https://github.com/myagues/flax_nerf/tree/e81d608128d92c8d15fd17c21834a5e47c185359).
 
-- `lego` scene from the Blender dataset with `--config.num_importance={0,64}`:
+### Blender - `lego`
+
+<details>
+    <summary>Commands</summary>
 
 ```
 python main.py \
-    --data_dir=/data/nerf_synthetic/lego \
-    --model_dir=logs_lego_64 \
-    --config=configs/test_blender_lego.py
-
-python render.py \
-    --data_dir=/data/nerf_synthetic/lego \
+    --data_dir=/data/nerf_synthetic \
     --model_dir=logs_lego_64 \
     --config=configs/test_blender_lego.py \
-    --config.render_factor=0 \
+    --config.batching=True \
+    --config.i_img=10000 \
+    --config.i_weights=10000
+
+python render.py \
+    --data_dir=/data/nerf_synthetic \
+    --model_dir=logs_lego_64 \
+    --config=configs/test_blender_lego.py \
+    --config.render_factor=1 \
     --config.testskip=0 \
     --render_video_set=test
 ```
 
 ```
 python main.py \
-    --data_dir=/data/nerf_synthetic_lego \
-    --model_dir=logs_lego_0 \
-    --config=configs/test_blender_lego.py \
-    --config.num_importance=0
+    --data_dir=/data/nerf_synthetic \
+    --model_dir=logs_lego_128 \
+    --config=configs/paper_blender_lego.py \
+    --config.batching=True \
+    --config.i_img=10000 \
+    --config.i_weights=10000
 
 python render.py \
-    --data_dir=/data/nerf_synthetic/lego \
-    --model_dir=logs_lego_0 \
-    --config=configs/test_blender_lego.py \
-    --config.num_importance=0 \
-    --config.render_factor=0 \
+    --data_dir=/data/nerf_synthetic \
+    --model_dir=logs_lego_128 \
+    --config=configs/paper_blender_lego.py \
+    --config.render_factor=1 \
     --config.testskip=0 \
     --render_video_set=test
 ```
+</details>
 
-Checkpoint path | Test set PSNR | Test set loss | TensorBoard.dev
-:---------------: | :-------------: | :-------------: |---------------:
-[lego_ckpt_0](https://drive.google.com/drive/folders/1h0r4ePMLueGExAqWJvWKUJORf9ju3XCF?usp=sharing) | 26.544 | 2.2e-3 | [2020-11-30](https://tensorboard.dev/experiment/WsKI4cYQS8OKDCMPFGPOLA)
-[lego_ckpt_64](https://drive.google.com/drive/folders/1gM3eVfYQgYLsCqUDHxv0I0N3BfgAHlWE?usp=sharing) | 31.779 | 6.6e-4 | [2020-11-30](https://tensorboard.dev/experiment/WsKI4cYQS8OKDCMPFGPOLA)
-
-- `vase` scene from the DeepVoxels dataset:
-
-```
-python main.py \
-    --data_dir=/data/deepvoxels \
-    --model_dir=logs_dv_vase \
-    --config=configs/test_dvox_greek.py \
-    --config.shape=vase \
-    --config.num_importance=128 \
-    --config.precrop_iters=500 \
-    --config.num_steps = 200000
-    --config.i_video=300000 \
-    --config.i_testset=300000 \
-    --config.i_img=5000 \
-    --config.i_print=250
-
-python render.py \
-    --data_dir=/data/deepvoxels \
-    --model_dir=logs_dv_vase \
-    --config=configs/test_dvox_greek.py \
-    --config.shape=vase \
-    --config.num_importance=128 \
-    --config.render_factor=0 \
-    --config.testskip=4 \
-    --render_video=False
-```
-
-Checkpoint path | Test set PSNR* | Test set loss* | TensorBoard.dev
-:---------------: | :-------------: | :-------------: |---------------:
-[vase_ckpt](https://drive.google.com/drive/folders/1yFquenIxwG2BfMrHOgiYZ_T9bSG8iUIN?usp=sharing) | 35.328 | 2.9e-4 | [2020-11-30](https://tensorboard.dev/experiment/HJN9sZNPQ9mknFNuVHkKkA)
-
-*Only a subset of the test set has been used, given that DeepVoxels has a big amount of images
+Checkpoint path | Test set PSNR | Paper PSNR | TensorBoard.dev
+:---------------: | :-------------: |  :-------------: | ---------------:
+[lego_400_64](https://drive.google.com/drive/folders/1d4bseKj_lBzhszqrY46402xUPxJ0rNyB?usp=sharing) | 31.48 | - | [2021-01-15](https://tensorboard.dev/experiment/kw5Sqp64S5akhnpku3LgAQ)
+[lego_800_128](https://drive.google.com/drive/folders/1AJ3h2k9cXUZdKz7In1U7MW8cDVzU-dbM?usp=sharing) | 32.29 | 32.54 | [2021-01-15](https://tensorboard.dev/experiment/kw5Sqp64S5akhnpku3LgAQ)
 
 ## Tips and caveats
 
-- You can test or debug multiple devices in a **CPU only** machine using `XLA_FLAGS` environment variable (more information in [JAX #1408](https://github.com/google/jax/issues/1408)). To simulate 4 devices:
+- You can test or debug multiple devices in a **CPU only** installation using `XLA_FLAGS` environment variable (more information in [JAX #1408](https://github.com/google/jax/issues/1408)). To simulate 4 devices:
 
 ```
 XLA_FLAGS="--xla_force_host_platform_device_count=4 xla_cpu_multi_thread_eigen=False intra_op_parallelism_threads=1"
 ```
 
-- Rendering images is done using `lax.map`, which means that the image size must be divisible by the number of devices
+- Try to minimize time spent on rendering intermediate results during training (`i_video`, `i_testset`) and rely on validation results in TensorBoard. Either save intermediate checkpoints and render after training or use `render_factor` and `testskip` to your advantage.
 
-- Try to minimize time spent on rendering intermediate results during training (`i_video`, `i_testset`) and rely on validation results in TensorBoard. Either save intermediate checkpoints and render after training or use `render_factor` and `testskip`
-
-- This implementation does not chunk the batch at training, which makes it less flexible for GPUs with small memory capacity. Here are some recommendations:
-
+- Here are some recommendations for reducing GPU memory footprint:
     - Use `nn.remat` decorator in your network module (more about `jax.remat` in [JAX #1749](https://github.com/google/jax/pull/1749))
     - Decrease model parameters (`net_depth`, `net_width`, `num_importance`, `num_rand`, `num_samples`)
-    - Use `--config.batching=True` to load a single training image per step, instead of precomputing all training rays upfront
-    - Using `bfloat16` will decrease memory usage by half, but reduces the performance results by a big margin, so it is **not** an option to use (no tests have been made with `float16`)
+    - Using `bfloat16` will decrease memory usage by half, but the low precision reduces performance by a big margin
 
 - The original repository ([bmild/nerf/issues](https://github.com/bmild/nerf/issues)) has many good comments and explanations from the authors and participants, which help to better understand the limitations and applications for this approach
 
 - [kwea123/nerf_pl](https://github.com/kwea123/nerf_pl) is another implementation, using PyTorch Lightning, that has many explanations and applications for your trained models
 
+- [google/jaxnerf](https://github.com/google-research/google-research/tree/master/jaxnerf) is _kind of_ an official version of NeRF with JAX and Flax
+
+- Training these models in Colab with TPUs is a bit of a stretch ([FAQ - Resource Limits](https://research.google.com/colaboratory/faq.html#resource-limits)), although you can use it for rendering (800px square image takes ~26s in an NVIDIA RTX 2080Ti vs ~7s in a TPUv2). Add the following commands to the top of your file:
+
+```
+import jax.tools.colab_tpu
+jax.tools.colab_tpu.setup_tpu()
+```
+
 ## TODO
 
-- Add LLFF data reader
-- Rendering routines use `lax.map`, which is problematic if image size is not divisible by the number of devices. Try using mask and padding for a more flexible implementation.
-- Redo DeepVoxels data reader with `tf.data.Dataset`
-- Most of the processes are done with batches of rays, rewrite everything for a single ray and `vmap/pmap/xmap` as needed (wait for JAX unified map API [JAX#2939](https://github.com/google/jax/issues/2939))
+- Rendering routines use `lax.map`, which is convenient for shaping outputs and fast at execution, although reshaping is a nuisance in some cases. Wait for mask redesign or rethink the execution.
+- Most of the processes are done with batches of rays, rewrite everything for a single ray and `vmap/pmap/xmap` as needed (wait for JAX unified map API [JAX#2939](https://github.com/google/jax/issues/2939)).
+- Add function docs and lint

--- a/configs/default.py
+++ b/configs/default.py
@@ -47,32 +47,27 @@ def get_config():
     config.raw_noise_std = 0.0           # std dev of noise added to regularize sigma_a output, 1e0 recommended
     config.render_only = False           # do not optimize, reload weights and render out render_poses path
     config.render_test = False           # render the test set instead of render_poses path
-    config.render_factor = 0             # downsampling factor to speed up rendering, set 4 or 8 for fast preview
+    config.down_factor = 1               # downsampling factor for the dataset
+    config.render_factor = 1             # downsampling factor to speed up rendering, set 4 or 8 for fast preview
+    config.white_bkgd = False            # whether to render synthetic data on a white bkgd (mandatory for dvoxels)
 
     # dataset options
     config.dataset_type = "llff"         # options: llff / blender / deepvoxels
+    config.shape = "fern"                # scene in the dataset
     config.testskip = 8                  # will load 1/N images from test/val sets, useful for large datasets like deepvoxels
-
-    # deepvoxels flags
-    config.shape = "greek"               # options: armchair / cube / greek / vase
-
-    # blender flags
-    config.white_bkgd = False            # whether to render synthetic data on a white bkgd (mandatory for dvoxels)
-    config.half_res = False              # whether to load blender synthetic data at 400x400 instead of 800x800
+    config.num_poses = 40                # number of poses to generate for renders in "blender" and "llff"
 
     # llff flags
     config.llff = ml_collections.ConfigDict()
-    config.llff.factor = 8               # downsample factor for LLFF images
-    config.llff.ndc = True               # whether to use normalized device coordinates (set for non-forward facing scenes)
     config.llff.lindisp = False          # sampling linearly in disparity rather than depth
     config.llff.spherify = False         # set for spherical 360 scenes
     config.llff.hold = 8                 # will take every 1/N images as LLFF test set, paper uses 8
 
     # logging / saving options
     config.i_print = 100                 # frequency of console printout and metric logging
-    config.i_img = 500                   # frequency of TensorBoard image logging
+    config.i_img = 5000                  # frequency of TensorBoard image logging
     config.i_weights = 5000              # frequency of weight ckpt saving
-    config.i_testset = 50000             # frequency of testset saving
-    config.i_video = 50000               # frequency of render_poses video saving
+    config.i_testset = 1000000           # frequency of testset saving
+    config.i_video = 1000000             # frequency of render_poses video saving
 
     return config

--- a/configs/paper_blender_lego.py
+++ b/configs/paper_blender_lego.py
@@ -1,5 +1,4 @@
 from configs import default as default_lib
-from jax import numpy as jnp
 
 
 def get_config():
@@ -7,6 +6,7 @@ def get_config():
     config = default_lib.get_config()
 
     config.dataset_type = "blender"
+    config.shape = "lego"
 
     config.batching = False
     config.num_importance = 128

--- a/configs/paper_llff_fern.py
+++ b/configs/paper_llff_fern.py
@@ -6,9 +6,9 @@ def get_config():
     config = default_lib.get_config()
 
     config.dataset_type = "llff"
-
-    config.llff.factor = 4
+    config.shape = "fern"
     config.llff.hold = 8
+    config.down_factor = 4
 
     config.num_importance = 128
     config.num_rand = 4096
@@ -17,5 +17,6 @@ def get_config():
     config.lr_decay = 250
     config.raw_noise_std = 1.0
     config.use_viewdirs = True
+    config.num_poses = 120
 
     return config

--- a/configs/test_blender_lego.py
+++ b/configs/test_blender_lego.py
@@ -1,5 +1,4 @@
 from configs import default as default_lib
-from jax import numpy as jnp
 
 
 def get_config():
@@ -7,7 +6,8 @@ def get_config():
     config = default_lib.get_config()
 
     config.dataset_type = "blender"
-    config.half_res = True
+    config.shape = "lego"
+    config.down_factor = 2
 
     config.batching = False
     config.num_importance = 64

--- a/configs/test_llff_fern.py
+++ b/configs/test_llff_fern.py
@@ -6,14 +6,15 @@ def get_config():
     config = default_lib.get_config()
 
     config.dataset_type = "llff"
-
-    config.llff.factor = 8
+    config.shape = "fern"
     config.llff.hold = 8
+    config.down_factor = 8
 
     config.num_importance = 64
     config.num_rand = 1024
     config.num_samples = 64
     config.raw_noise_std = 1.0
     config.use_viewdirs = True
+    config.num_poses = 120
 
     return config

--- a/datasets/input_pipeline.py
+++ b/datasets/input_pipeline.py
@@ -1,0 +1,200 @@
+import functools
+
+import jax
+
+import tensorflow as tf
+
+from flax import jax_utils
+
+from clu import deterministic_data
+from datasets import load_blender, load_deepvoxels, load_llff
+
+
+AUTOTUNE = tf.data.experimental.AUTOTUNE
+
+
+def prepare_train_data(dataset):
+    """Convert a input batch from TF tensors to NumPy arrays."""
+    local_device_count = jax.local_device_count()
+
+    def _prepare(x):
+        x = x._numpy()
+        return x.reshape((local_device_count,) + x.shape[1:])
+
+    it = map(lambda x: jax.tree_map(_prepare, x), dataset)
+    return jax_utils.prefetch_to_device(it, 2)
+
+
+def batching_sample(features, config):
+    rays_range, _ = tf.unstack(tf.shape(features["rays"]))
+    kwargs = {"minval": 0, "maxval": rays_range, "dtype": tf.int32}
+    if "rng" in features:
+        idx = tf.random.stateless_uniform([config.num_rand], features["rng"], **kwargs)
+    else:
+        idx = tf.random.uniform([config.num_rand], **kwargs)
+    rays = tf.gather(features["rays"], idx)
+    image = tf.gather(features["image"], idx)
+    return {"rays": rays, "image": image}
+
+
+def prepare_rays(features, config, c2w_static_cam=None):
+    """
+    Build rays for rendering.
+    Args:
+        rays: (2, num_rays, 3) origin and direction generated rays
+        hwf: (3) tuple containing image height, width and focal length
+        config: model and rendering config
+        c2w: (3, 4) camera-to-world transformation matrix
+        c2w_static_cam: (3, 4) transformation matrix for camera
+    Returns:
+        rays: (img_h, img_w, *) generated rays
+    """
+    rays_o, rays_d = get_rays(*features["hwf"], features["pose"])
+
+    viewdirs = None
+    if config.use_viewdirs:
+        # provide ray directions as input
+        viewdirs = rays_d
+        # make all directions unit magnitude
+        viewdirs /= tf.linalg.norm(viewdirs, axis=-1, keepdims=True)
+
+        if c2w_static_cam is not None:
+            # special case to visualize effect of viewdirs
+            rays_o, rays_d = get_rays(*features["hwf"], c2w_static_cam)
+
+    # for forward facing scenes
+    if not config.llff.spherify and config.dataset_type == "llff":
+        rays_o, rays_d = ndc_rays(*features["hwf"], 1.0, rays_o, rays_d)
+
+    rays = [rays_o, rays_d]
+    if viewdirs is not None:
+        rays.append(viewdirs)
+    rays = tf.concat(rays, axis=-1)
+    return {"rays": rays, "image": features["image"], "hwf": features["hwf"]}
+
+
+def ndc_rays(img_h, img_w, focal, near, rays_o, rays_d):
+    """Normalized device coordinate rays.
+    Space such that the canvas is a cube with sides [-1, 1] in each axis.
+    Args:
+        img_h: height in pixels
+        img_w: width in pixels
+        focal: focal length of the pinhole camera
+        near: near depth bound for the scene
+        rays_o: (num_rays, 3) origin rays
+        rays_d: (num_rays, 3) direction rays
+    Returns:
+        rays_o: (num_rays, 3) origin rays in NDC
+        rays_d: (num_rays, 3) direction rays in NDC
+    """
+    # shift ray origins to near plane
+    t = -(near + rays_o[..., 2]) / rays_d[..., 2]
+    rays_o = rays_o + t[..., None] * rays_d
+    ox = rays_o[..., 0] / rays_o[..., 2]
+    oy = rays_o[..., 1] / rays_o[..., 2]
+
+    # projection
+    o0 = -1.0 / (float(img_w) / (2.0 * focal)) * ox
+    o1 = -1.0 / (float(img_h) / (2.0 * focal)) * oy
+    o2 = 1.0 + 2.0 * near / rays_o[..., 2]
+
+    d0 = -1.0 / (float(img_w) / (2.0 * focal)) * (rays_d[..., 0] / rays_d[..., 2] - ox)
+    d1 = -1.0 / (float(img_h) / (2.0 * focal)) * (rays_d[..., 1] / rays_d[..., 2] - oy)
+    d2 = 1 - o2
+
+    rays_o = tf.stack([o0, o1, o2], axis=-1)
+    rays_d = tf.stack([d0, d1, d2], axis=-1)
+    return rays_o, rays_d
+
+
+def get_rays(img_h, img_w, focal, c2w):
+    """Get ray origins and directions from a pinhole camera.
+    Args:
+        img_h: height in pixels
+        img_w: width in pixels
+        focal: focal length of the pinhole camera
+        c2w: (3, 4) camera to world coordinate transformation matrix
+    Returns:
+        rays: (2, img_h * img_w, 3) stacked origin and direction rays
+    """
+    i, j = tf.meshgrid(tf.range(img_w), tf.range(img_h), indexing="xy")
+    i = (tf.cast(i, dtype=tf.float32) - float(img_w) * 0.5) / float(focal)
+    j = -(tf.cast(j, dtype=tf.float32) - float(img_h) * 0.5) / float(focal)
+    dirs = tf.stack([i, j, -tf.ones_like(i, dtype=tf.float32)], axis=-1)
+    rays_d = tf.einsum("ijl,kl", dirs, c2w[:3, :3])
+    rays_o = tf.broadcast_to(c2w[:3, -1], tf.shape(rays_d))
+    return rays_o, rays_d
+
+
+def get_dataset(data_dir, config, rng=None, cache=True, **kwargs):
+    ds_dict = {
+        "blender": load_blender.get_blender,
+        "deepvoxels": load_deepvoxels.get_deepvoxels,
+        "llff": load_llff.get_llff,
+    }
+    assert (
+        config.dataset_type in ds_dict.keys()
+    ), f"{config.dataset_type} is not one of 'blender', 'deepvoxels' or 'llff'."
+    ds_output = ds_dict[config.dataset_type](data_dir, config, **kwargs)
+    datasets, counts, optics, render_poses_ds, static_pose, num_poses = ds_output
+
+    if rng is not None:
+        rng_0, rng_1, rng_2 = list(jax.random.split(rng, 3))
+    else:
+        rng_0, rng_1, rng_2 = 3 * [[None, None]]
+
+    datasets_list, counts_list = [], []
+    rays_fn = functools.partial(prepare_rays, config=config)
+    for idx, (ds, count) in enumerate(zip(datasets, counts)):
+        ds.options().experimental_optimization.map_parallelization = True
+        ds.options().experimental_threading.private_threadpool_size = 48
+        ds.options().experimental_threading.max_intra_op_parallelism = 1
+        if idx == 0:  # train
+            ds = ds.map(rays_fn, num_parallel_calls=AUTOTUNE)  # load rays
+
+            if config.batching:
+
+                def map_reshape(features):
+                    *_, chn = tf.unstack(tf.shape(features["rays"]))
+                    rays = tf.reshape(features["rays"], [-1, chn])
+                    image = tf.reshape(features["image"], [-1, 3])
+                    return {"rays": rays, "image": image, "hwf": features["hwf"]}
+
+                ds = ds.batch(count)
+                ds = ds.map(map_reshape, num_parallel_calls=AUTOTUNE)
+                ds = ds.cache().repeat()
+                map_fn = functools.partial(batching_sample, config=config)
+                if rng is not None:
+                    ds = deterministic_data._preprocess_with_per_example_rng(
+                        ds, map_fn, rng=rng_0
+                    )
+                else:
+                    ds = ds.map(map_fn, num_parallel_calls=AUTOTUNE)
+            else:
+                if cache:
+                    ds = ds.cache()
+                ds = ds.repeat().shuffle(count, seed=rng_1[0])
+            ds = ds.batch(jax.local_device_count()).prefetch(AUTOTUNE)
+            ds = prepare_train_data(ds)
+        else:  # val or test
+            ds = ds.repeat()
+            if idx == 1:
+                ds = ds.shuffle(count, seed=rng_2[0])
+            ds = ds.map(rays_fn, num_parallel_calls=AUTOTUNE).prefetch(AUTOTUNE)
+            ds = iter(ds)
+        datasets_list.append(ds)
+        counts_list.append(count)
+
+    ds_rays_fn = (
+        lambda x: render_poses_ds.map(x, num_parallel_calls=AUTOTUNE)
+        .repeat()
+        .prefetch(AUTOTUNE)
+    )
+    render_rays_ds = iter(ds_rays_fn(rays_fn))
+
+    render_rays_vdirs_ds = None
+    if config.use_viewdirs:
+        rays_fn = functools.partial(rays_fn, c2w_static_cam=static_pose)
+        render_rays_vdirs_ds = iter(ds_rays_fn(rays_fn))
+    render_datasets = render_rays_ds, render_rays_vdirs_ds, num_poses
+    return datasets_list, counts_list, optics, render_datasets

--- a/datasets/load_deepvoxels.py
+++ b/datasets/load_deepvoxels.py
@@ -2,63 +2,31 @@ import functools
 import glob
 import os
 
-import imageio
-
 import numpy as np
 import pandas as pd
+import tensorflow as tf
 
 from absl import logging
 
+AUTOTUNE = tf.data.experimental.AUTOTUNE
 
-def load_pose(file_path):
-    assert os.path.isfile(file_path)
-    return np.loadtxt(file_path, dtype=np.float32).reshape([4, 4])
-
-
-def dir2poses(dataset_dir, testskip=None):
-    posedir_file = sorted(glob.glob(os.path.join(dataset_dir, "pose", "*.txt")))
-    poses = np.stack([load_pose(f) for f in posedir_file])
-    transf = np.array(
-        [
-            [1, 0, 0, 0],
-            [0, -1, 0, 0],
-            [0, 0, -1, 0],
-            [0, 0, 0, 1],
-        ]
-    )
-    poses = poses @ transf
-    poses = poses[:, :3, :4].astype(np.float32)
-    if testskip is not None:
-        skip = 1 if testskip == 0 else testskip
-        return poses[::skip]
-    return poses
+transf = np.array([[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]])
 
 
-def get_imgs(dataset_dir, testskip=None):
-    img_list = sorted(glob.glob(os.path.join(dataset_dir, "rgb", "*.png")))
-    imgs = np.stack([imageio.imread(f) / 255.0 for f in img_list]).astype(np.float32)
-    if testskip is not None:
-        skip = 1 if testskip == 0 else testskip
-        return imgs[::skip]
-    return imgs
-
-
-def parse_intrinsics(dataset_dir, target_side_len, invert_y=False):
+def parse_intrinsics(data_dir, target_side_len, invert_y=False):
     # Get camera intrinsics
-    filepath = os.path.join(dataset_dir, "intrinsics.txt")
+    filepath = os.path.join(data_dir, "intrinsics.txt")
     df = pd.read_table(filepath, header=None, sep=" ", dtype=np.float32)
     f, cx, cy, _ = df.values[0]
     *grid_barycenter, _ = df.values[1]
     near_plane, *_ = df.values[2]
     scale, *_ = df.values[3]
     height, width, *_ = df.values[4]
-
     # try:
     #     world2cam_poses, *_ = df.values[5]
     # except ValueError:
     #     world2cam_poses = False
-
-    logging.info(
+    logging.debug(
         "cx: %f, cy: %f, f: %f, height: %f, width: %f", cx, cy, f, height, width
     )
 
@@ -71,40 +39,100 @@ def parse_intrinsics(dataset_dir, target_side_len, invert_y=False):
     full_intrinsic = np.array(
         [[fx, 0, cx, 0], [0, fy, cy, 0], [0, 0, 1, 0], [0, 0, 0, 1]]
     ).astype(np.float32)
-
     return full_intrinsic, grid_barycenter, scale, near_plane
 
 
-def load_dv_data(dataset_dir, scene="cube", testskip=8):
-    dataset_subdir = lambda split: os.path.join(dataset_dir, split, scene)
-    assert os.path.exists(dataset_subdir("train"))
+def get_near_far_vals(data_dir, config):
+    def get_pose(pose_path):
+        pose = tf.io.decode_csv(tf.io.read_file(pose_path), [0.0] * 16, field_delim=" ")
+        pose = tf.reshape(pose, (4, 4)) @ transf
+        pose = tf.cast(pose, tf.float32)
+        return pose
 
-    img_h = 512
-    img_w = 512
+    dataset_subdir = lambda split: os.path.join(data_dir, split, config.shape, "pose")
+    item_size = 0
+    for split in ["train", "validation", "test"]:
+        posedir_file = sorted(glob.glob(os.path.join(dataset_subdir(split), "*.txt")))
+        skip = 1 if split == "train" or config.testskip == 0 else config.testskip
+        ds = tf.data.Dataset.from_tensor_slices(posedir_file[::skip])
+        item_size += ds.cardinality().numpy()
+        if split == "train":
+            datasets = ds
+        else:
+            datasets = datasets.concatenate(ds)
+    poses = datasets.map(get_pose, num_parallel_calls=AUTOTUNE).batch(item_size)
+
+    hemi_R = np.mean(
+        np.linalg.norm(np.concatenate(list(poses.as_numpy_iterator())), axis=-1)
+    )
+    near = hemi_R - 1.0
+    far = hemi_R + 1.0
+    return near, far
+
+
+def get_image_data(file_path, pose_path, focal, factor):
+    img = tf.io.decode_png(tf.io.read_file(file_path))
+    img = tf.image.convert_image_dtype(img, dtype=tf.float32)
+    height, width, _ = tf.unstack(tf.shape(img))
+
+    pose = tf.io.decode_csv(tf.io.read_file(pose_path), [0.0] * 16, field_delim=" ")
+    pose = tf.reshape(pose, (4, 4)) @ transf
+    pose = tf.cast(pose, tf.float32)
+
+    if factor > 1:
+        height //= factor
+        width //= factor
+        focal /= float(factor)
+        img = tf.image.resize(img, [height, width], method=tf.image.ResizeMethod.AREA)
+
+    return {"image": img, "pose": pose, "hwf": (height, width, float(focal))}
+
+
+def load_data(data_dir, split, config, img_h, img_w, factor):
+    dataset_subdir = lambda split: os.path.join(data_dir, split, config.shape)
+    assert os.path.exists(dataset_subdir(split))
+    assert config.white_bkgd == True
 
     full_intrinsic, grid_barycenter, scale, near_plane = parse_intrinsics(
-        dataset_subdir("train"), img_h
+        dataset_subdir(split), img_h
     )
     focal = full_intrinsic[0, 0]
 
-    logging.info("Full intrinsic: %s", full_intrinsic)
-    logging.info("Grid barycenter: %s", grid_barycenter)
-    logging.info("Scale: %s", scale)
-    logging.info("Near plane: %s", near_plane)
-    # logging.info("World to camera poses: %s", w2c_poses)
-    logging.info("Image height: %d, image width: %d, focal: %.5f", img_h, img_w, focal)
+    logging.debug("Full intrinsic: %s", full_intrinsic)
+    logging.debug("Grid barycenter: %s", grid_barycenter)
+    logging.debug("Scale: %s", scale)
+    logging.debug("Near plane: %s", near_plane)
+    # logging.debug("World to camera poses: %s", w2c_poses)
 
-    train_poses = dir2poses(dataset_subdir("train"))
-    val_poses = dir2poses(dataset_subdir("validation"), testskip=testskip)
-    test_poses = dir2poses(dataset_subdir("test"), testskip=testskip)
-    all_poses = np.concatenate([train_poses, val_poses, test_poses])
-    del train_poses, val_poses
+    skip = 1 if split == "train" or config.testskip == 0 else config.testskip
+    fnames = sorted(glob.glob(os.path.join(dataset_subdir(split), "rgb", "*.png")))
+    poses = sorted(glob.glob(os.path.join(dataset_subdir(split), "pose", "*.txt")))
 
-    train_imgs = get_imgs(dataset_subdir("train"))
-    val_imgs = get_imgs(dataset_subdir("validation"), testskip=testskip)
-    test_imgs = get_imgs(dataset_subdir("test"), testskip=testskip)
+    map_fn = functools.partial(get_image_data, focal=focal, factor=factor)
+    dataset = tf.data.Dataset.from_tensor_slices((fnames[::skip], poses[::skip]))
+    counts = dataset.cardinality().numpy()
+    dataset = dataset.map(map_fn, num_parallel_calls=AUTOTUNE)
+    return dataset, counts
 
-    all_imgs = np.concatenate([train_imgs, val_imgs, test_imgs])
-    counts = [train_imgs.shape[0], val_imgs.shape[0], test_imgs.shape[0]]
 
-    return all_imgs, all_poses, test_poses, (img_h, img_w, focal), counts
+def get_deepvoxels(data_dir, config):
+    img_h = 512
+    img_w = 512
+    near, far = get_near_far_vals(data_dir, config)
+    load_data_fn = functools.partial(
+        load_data, data_dir, config=config, img_h=img_h, img_w=img_w
+    )
+    train_ds, train_items = load_data_fn("train", factor=config.down_factor)
+    val_ds, val_items = load_data_fn("validation", factor=config.down_factor)
+    test_ds, test_items = load_data_fn(
+        "test", factor=(config.down_factor * config.render_factor)
+    )
+    render_example = next(iter(test_ds))
+    static_pose = render_example["pose"].numpy()
+    hwf = next(iter(train_ds))["hwf"]
+    r_hwf = render_example["hwf"]
+
+    datasets = train_ds, val_ds, test_ds
+    counts = train_items, val_items, test_items
+    optics = hwf, r_hwf, near, far
+    return datasets, counts, optics, test_ds, static_pose, test_items

--- a/datasets/load_llff.py
+++ b/datasets/load_llff.py
@@ -1,0 +1,236 @@
+"""Some LLFF preprocessing functions taken from kwea123's NeRF implementation.
+https://github.com/kwea123/nerf_pl/blob/master/datasets/llff.py
+"""
+
+import functools
+import glob
+import os
+
+import numpy as np
+import tensorflow as tf
+
+from absl import logging
+
+
+AUTOTUNE = tf.data.experimental.AUTOTUNE
+normalize = lambda x: x / np.linalg.norm(x)
+
+
+def average_poses(poses):
+    # 1. Compute the center
+    center = poses[..., 3].mean(0)  # (3)
+
+    # 2. Compute the z axis
+    z = normalize(poses[..., 2].mean(0))  # (3)
+
+    # 3. Compute axis y' (no need to normalize as it's not the final output)
+    y_ = poses[..., 1].mean(0)  # (3)
+
+    # 4. Compute the x axis
+    x = normalize(np.cross(y_, z))  # (3)
+
+    # 5. Compute the y axis (as z and x are normalized, y is already of norm 1)
+    y = np.cross(z, x)  # (3)
+
+    pose_avg = np.stack([x, y, z, center], 1)  # (3, 4)
+    return pose_avg
+
+
+def recenter_poses(poses):
+    """Center the poses so that we can use NDC."""
+    pose_avg = average_poses(poses)  # (3, 4)
+    pose_avg_homo = np.eye(4)
+    # convert to homogeneous coordinate for faster computation
+    pose_avg_homo[:3] = pose_avg
+    last_row = np.tile(np.array([0, 0, 0, 1]), (len(poses), 1, 1))  # (N_images, 1, 4)
+    poses_homo = np.concatenate([poses, last_row], 1)  # (N_images, 4, 4)
+
+    poses_centered = np.linalg.inv(pose_avg_homo) @ poses_homo  # (N_images, 4, 4)
+    poses_centered = poses_centered[:, :3]  # (N_images, 3, 4)
+    return poses_centered, np.linalg.inv(pose_avg_homo)
+
+
+def create_spheric_poses(radius, num_poses):
+    """
+    Create circular poses around z axis.
+    Inputs:
+        radius: the (negative) height and the radius of the circle.
+        num_poses: int, number of poses to create along the path.
+    Outputs:
+        spheric_poses: (num_poses, 3, 4) the poses in the circular path.
+    """
+
+    def spheric_pose(theta, phi, radius):
+        trans_t = lambda t: np.array(
+            [
+                [1, 0, 0, 0],
+                [0, 1, 0, -0.9 * t],
+                [0, 0, 1, t],
+                [0, 0, 0, 1],
+            ]
+        )
+
+        rot_phi = lambda phi: np.array(
+            [
+                [1, 0, 0, 0],
+                [0, np.cos(phi), -np.sin(phi), 0],
+                [0, np.sin(phi), np.cos(phi), 0],
+                [0, 0, 0, 1],
+            ]
+        )
+
+        rot_theta = lambda th: np.array(
+            [
+                [np.cos(th), 0, -np.sin(th), 0],
+                [0, 1, 0, 0],
+                [np.sin(th), 0, np.cos(th), 0],
+                [0, 0, 0, 1],
+            ]
+        )
+
+        c2w = rot_theta(theta) @ rot_phi(phi) @ trans_t(radius)
+        c2w = np.array([[-1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]]) @ c2w
+        return c2w[:3]
+
+    spheric_poses = []
+    for th in np.linspace(0, 2 * np.pi, num_poses, endpoint=False):
+        spheric_poses += [
+            spheric_pose(th, -np.pi / 5, radius)
+        ]  # 36 degree view downwards
+    return np.stack(spheric_poses, 0)
+
+
+def create_spiral_poses(radii, focus_depth, num_poses):
+    """
+    Computes poses that follow a spiral path for rendering purpose.
+    See https://github.com/Fyusion/LLFF/issues/19
+    In particular, the path looks like: https://tinyurl.com/ybgtfns3
+    Inputs:
+        radii: (3) radii of the spiral for each axis
+        focus_depth: float, the depth that the spiral poses look at
+        num_poses: int, number of poses to create along the path
+    Outputs:
+        poses_spiral: (num_poses, 3, 4) the poses in the spiral path
+    """
+    poses_spiral = []
+    for t in np.linspace(
+        0, 4 * np.pi, num_poses, endpoint=False
+    ):  # rotate 4pi (2 rounds)
+        # the parametric function of the spiral (see the interactive web)
+        center = np.array([np.cos(t), -np.sin(t), -np.sin(0.5 * t)]) * radii
+
+        # the viewing z axis is the vector pointing from the @focus_depth plane
+        # to @center
+        z = normalize(center - np.array([0, 0, -focus_depth]))
+
+        # compute other axes as in @average_poses
+        y_ = np.array([0, 1, 0])  # (3)
+        x = normalize(np.cross(y_, z))  # (3)
+        y = np.cross(z, x)  # (3)
+
+        poses_spiral += [np.stack([x, y, z, center], 1)]  # (3, 4)
+    return np.stack(poses_spiral, 0)  # (num_poses, 3, 4)
+
+
+def get_image_data(file_path, pose, factor, focal):
+    img = tf.io.decode_png(tf.io.read_file(file_path))
+    img = tf.image.convert_image_dtype(img, dtype=tf.float32)
+    height, width, _ = tf.unstack(tf.shape(img))
+
+    if factor > 1:
+        height //= factor
+        width //= factor
+        focal /= factor
+        img = tf.image.resize(
+            img,
+            [height, width],
+            method=tf.image.ResizeMethod.AREA,
+            preserve_aspect_ratio=True,
+        )
+    return {"image": img, "pose": pose, "hwf": (height, width, float(focal))}
+
+
+def load_data(data_dir, config, recenter=True, bd_factor=0.75, num_poses=120):
+
+    fnames = sorted(glob.glob(os.path.join(data_dir, config.shape, "images", "*")))
+    poses_arr = np.load(os.path.join(data_dir, config.shape, "poses_bounds.npy"))
+
+    poses, bounds = np.split(poses_arr, [15], axis=-1)
+    poses = poses.reshape([-1, 3, 5]).astype(np.float32)
+    assert len(fnames) == poses.shape[0]
+    *_, focal = poses[0, :, -1]
+    poses = np.concatenate([poses[..., 1:2], -poses[..., :1], poses[..., 2:4]], -1)
+
+    if recenter:
+        poses, _ = recenter_poses(poses)
+    distances_from_center = np.linalg.norm(poses[..., 3], axis=1)
+    val_idx = np.argmin(distances_from_center)
+
+    # Rescale if bd_factor is provided
+    scale_factor = 1.0 if bd_factor is None else (bounds.min() * bd_factor)
+    bounds /= scale_factor
+    poses[..., 3] /= scale_factor
+
+    val_fnames, val_poses = fnames[val_idx], poses[val_idx, None].astype(np.float32)
+    fnames.pop(val_idx)
+    poses = np.delete(poses, val_idx, 0)
+    logging.info("Validation image is: %s", val_fnames)
+
+    split_idx = np.arange(len(poses))[:: config.llff.hold]
+    test_fnames = fnames[:: config.llff.hold]
+    test_poses = np.take(poses, split_idx, axis=0).astype(np.float32)
+
+    train_fnames = np.delete(fnames, split_idx, 0)
+    train_poses = np.delete(poses, split_idx, 0).astype(np.float32)
+
+    if config.llff.spherify:
+        near = bounds.min()
+        far = min(8 * near, bounds.max())  # focus on central object only
+        radius = 1.1 * bounds.min()
+        render_poses = create_spheric_poses(radius, num_poses)
+    else:
+        near, far = 0, 1
+        # hardcoded, this is numerically close to the formula given in the original repo
+        # mathematically if near=1 and far=infinity, then this number will converge to 4
+        focus_depth = 3.5
+        radii = np.percentile(np.abs(poses[..., 3]), 90, axis=0)
+        render_poses = create_spiral_poses(radii, focus_depth, num_poses)
+
+    map_fn = functools.partial(
+        get_image_data,
+        factor=config.down_factor,
+        focal=focal,
+    )
+    train_ds = tf.data.Dataset.from_tensor_slices((train_fnames, train_poses))
+    train_ds = train_ds.map(map_fn, num_parallel_calls=AUTOTUNE)
+
+    val_ds = tf.data.Dataset.from_tensor_slices(([val_fnames], val_poses))
+    val_ds = val_ds.map(map_fn, num_parallel_calls=AUTOTUNE)
+
+    map_fn = functools.partial(
+        get_image_data,
+        factor=(config.down_factor * config.render_factor),
+        focal=focal,
+    )
+    test_ds = tf.data.Dataset.from_tensor_slices((test_fnames, test_poses))
+    test_ds = test_ds.map(map_fn, num_parallel_calls=AUTOTUNE)
+
+    datasets = train_ds, val_ds, test_ds
+    counts = map(lambda x: x.cardinality().numpy(), datasets)
+    return datasets, counts, render_poses.astype(np.float32), near, far
+
+
+def get_llff(data_dir, config, **kwargs):
+    datasets, counts, render_poses, near, far = load_data(data_dir, config, **kwargs)
+    train_ds, _, test_ds = datasets
+    hwf = next(iter(train_ds))["hwf"]
+    r_hwf = next(iter(test_ds))["hwf"]
+    optics = hwf, r_hwf, near, far
+
+    render_poses_ds = tf.data.Dataset.from_tensor_slices(list(render_poses))
+    static_pose = next(iter(render_poses_ds))
+    render_poses_ds = render_poses_ds.map(
+        lambda x: {"image": False, "pose": x, "hwf": r_hwf}, num_parallel_calls=AUTOTUNE
+    )
+    num_poses = len(render_poses)
+    return datasets, counts, optics, render_poses_ds, static_pose.numpy(), num_poses

--- a/render.py
+++ b/render.py
@@ -1,85 +1,91 @@
 import functools
 import os
-import time
 
 import imageio
 import jax
 import numpy as np
+import tensorflow as tf
 
 from absl import app, flags, logging
 from flax import jax_utils, optim, struct
-from flax.training import checkpoints
-from jax import numpy as jnp, lax, random
+from flax.training import checkpoints, common_utils
+from jax import numpy as jnp, lax
 from jax.config import config as jax_config
 from ml_collections import config_flags
-from typing import Any, Optional
+from tqdm import tqdm
+from typing import Optional
 
-from datasets import load_blender, load_deepvoxels
+from datasets.input_pipeline import get_dataset
 from model import NeRF
-from rays_utils import prepare_rays
-from utils import eval_step, psnr_fn
+from utils import eval_step
 
 jax_config.enable_omnistaging()
+tf.config.experimental.set_visible_devices([], "GPU")
 
 FLAGS = flags.FLAGS
 
 config_flags.DEFINE_config_file(
-    "config",
-    os.path.join(os.path.dirname(__file__), "configs/default.py"),
-    "File path to the hyperparameter configuration.",
+    "config", None, "File path to the hyperparameter configuration."
 )
-
-flags.DEFINE_integer("seed", default=0, help=("Initialization seed."))
-flags.DEFINE_string("data_dir", default=None, help=("Directory containing data files."))
-flags.DEFINE_string("model_dir", default=None, help=("Directory to store model data."))
-flags.DEFINE_string("save_dir", default=None, help=("Directory to store outputs."))
+flags.DEFINE_integer("seed", default=0, help="Initialization seed.")
+flags.DEFINE_string("data_dir", default=None, help="Directory containing data files.")
+flags.DEFINE_string("model_dir", default=None, help="Directory to store model data.")
+flags.DEFINE_string("save_dir", default=None, help="Directory to store outputs.")
 flags.DEFINE_string(
     "render_video_set",
     default="render",
-    help=("Subset of data to use to render the video."),
+    help="Subset of data to use to render the video.",
 )
-flags.DEFINE_bool("render_video", default=True, help=("Whether to render video."))
-flags.DEFINE_bool("render_testset", default=True, help=("Whether to render testset."))
-flags.DEFINE_string(
-    "jax_backend_target",
-    default=None,
-    help=("JAX backend target to use. Can be used with UPTC."),
+flags.DEFINE_bool("render_video", default=True, help="Whether to render video.")
+flags.DEFINE_bool("render_testset", default=False, help="Whether to render testset.")
+
+
+to_np = (
+    lambda x, y, z: np.asarray(x)
+    .reshape(1, y[0] + z, y[1], -1)
+    .astype(np.float32)[:, z:]
 )
+to_rgb = lambda x: (255 * np.clip(np.asarray(x), 0, 1)).astype(np.uint8)
+psnr_fn = lambda x: -10.0 * np.log(x) / np.log(10.0)
+
+
+def disp_post(disp, config):
+    if config.dataset_type == "llff":
+        disp = (disp - disp.min()) / np.clip(disp.max() - disp.min(), 1e-5, None)
+    return disp
+
+
+def prepare_render_data(rays):
+    padding = 0
+    img_h, img_w, chn = rays.shape
+    rays_remaining = np.prod(img_h) % jax.local_device_count()
+    if rays_remaining != 0:
+        padding = jax.local_device_count() - rays_remaining
+        rays = np.pad(rays, ((padding, 0), (0, 0), (0, 0)), mode="edge")
+    return rays.reshape(jax.local_device_count(), -1, img_w, chn), padding
 
 
 def gen_video(data, filename, hwf, step, ch=3):
     img_h, img_w, _ = hwf
-    data = 255 * jnp.clip(data.reshape([-1, img_h, img_w, ch]), 0, 1)
+    data = to_rgb(data.reshape([-1, img_h, img_w, ch]))
     if FLAGS.save_dir is None:
         out_path = FLAGS.model_dir
     else:
         out_path = FLAGS.save_dir
-    imageio.mimwrite(
-        os.path.join(out_path, f"{filename}_{step:06d}.mp4"),
-        data.astype(jnp.uint8),
-        fps=30,
-        quality=8,
-    )
-    imageio.mimwrite(
-        os.path.join(out_path, f"{filename}_{step:06d}.gif"),
-        data.astype(jnp.uint8),
-        fps=30,
-    )
+    imageio.mimwrite(os.path.join(out_path, f"{filename}_{step:06d}.mp4"), data, fps=30)
+    imageio.mimwrite(os.path.join(out_path, f"{filename}_{step:06d}.gif"), data, fps=30)
 
 
-def save_test_imgs(data, hwf, step, ch=3):
+def save_test_imgs(data, hwf, step, idx, ch=3):
     img_h, img_w, _ = hwf
-    data = 255 * jnp.clip(data.reshape([-1, img_h, img_w, ch]), 0, 1)
+    data = to_rgb(data.reshape([img_h, img_w, ch]))
     if FLAGS.save_dir is None:
         out_path = FLAGS.model_dir
     else:
         out_path = FLAGS.save_dir
     save_path = os.path.join(out_path, f"testset_{step:06d}")
     os.makedirs(save_path, exist_ok=True)
-    [
-        imageio.imwrite(os.path.join(save_path, f"{idx:02d}.png"), x)
-        for idx, x in enumerate(data.astype(jnp.uint8))
-    ]
+    imageio.imwrite(os.path.join(save_path, f"{idx:02d}.png"), data)
 
 
 def initialized(key, input_pts_shape, input_viewdirs_shape, model_config):
@@ -105,83 +111,26 @@ class TrainState:
 
 
 def main(_):
-    if FLAGS.jax_backend_target:
-        logging.info("Using JAX backend target %s", FLAGS.jax_backend_target)
-        jax_config.update("jax_xla_backend", "tpu_driver")
-        jax_config.update("jax_backend_target", FLAGS.jax_backend_target)
-
+    assert FLAGS.config.down_factor > 0 and FLAGS.config.render_factor > 0
     logging.info("JAX host: %d / %d", jax.host_id(), jax.host_count())
     logging.info("JAX local devices: %r", jax.local_devices())
 
-    rng = random.PRNGKey(FLAGS.seed)
-    rng, init_rng_coarse, init_rng_fine = random.split(rng, 3)
-    n_devices = jax.device_count()
+    rng = jax.random.PRNGKey(FLAGS.seed)
+    rng, init_rng_coarse, init_rng_fine = jax.random.split(rng, 3)
 
     ### Load dataset and data values
-    if FLAGS.config.dataset_type == "blender":
-        images, poses, render_poses, hwf, counts = load_blender.load_data(
-            FLAGS.data_dir,
-            half_res=FLAGS.config.half_res,
-            testskip=FLAGS.config.testskip,
-        )
-        logging.info("Loaded blender, total images: %d", images.shape[0])
+    datasets, counts, optics, render_datasets = get_dataset(
+        FLAGS.data_dir, FLAGS.config, num_poses=FLAGS.config.num_poses
+    )
+    train_ds, val_ds, test_ds = datasets
+    train_items, val_items, test_items = counts
+    hwf, r_hwf, near, far = optics
+    render_ds, render_vdirs_ds, num_poses = render_datasets
 
-        near = 2.0
-        far = 6.0
-
-        if FLAGS.config.white_bkgd:
-            images = images[..., :3] * images[..., -1:] + (1.0 - images[..., -1:])
-        else:
-            images = images[..., :3]
-
-    elif FLAGS.config.dataset_type == "deepvoxels":
-        images, poses, render_poses, hwf, counts = load_deepvoxels.load_dv_data(
-            FLAGS.data_dir,
-            scene=FLAGS.config.shape,
-            testskip=FLAGS.config.testskip,
-        )
-        hemi_R = np.mean(np.linalg.norm(poses[:, :3, -1], axis=-1))
-        near = hemi_R - 1.0
-        far = hemi_R + 1.0
-        logging.info(
-            "Loaded deepvoxels (%s), total images: %d",
-            FLAGS.config.shape,
-            images.shape[0],
-        )
-    else:
-        raise ValueError(f"Dataset '{FLAGS.config.dataset_type}' is not available.")
-
-    img_h, img_w, focal = hwf
-    logging.info("Images splits: %s", counts)
-    logging.info("Render poses: %s", render_poses.shape)
-    logging.info("Image height: %d, image width: %d, focal: %.5f", img_h, img_w, focal)
-
-    train_imgs, val_imgs, test_imgs, *_ = np.split(images, np.cumsum(counts))
-    train_poses, val_poses, test_poses, *_ = np.split(poses, np.cumsum(counts))
-
-    if FLAGS.config.render_factor > 0:
-        # render downsampled for speed
-        r_img_h = img_h // FLAGS.config.render_factor
-        r_img_w = img_w // FLAGS.config.render_factor
-        r_focal = focal / FLAGS.config.render_factor
-        r_hwf = r_img_h, r_img_w, r_focal
-    else:
-        r_hwf = hwf
-
-    ### Pre-compute rays
-    @functools.partial(jax.jit, static_argnums=(0,))
-    def prep_rays(hwf, c2w, c2w_sc=None):
-        if c2w_sc is not None:
-            c2w_sc = c2w_sc[:3, :4]
-        return prepare_rays(None, hwf, FLAGS.config, near, far, c2w[:3, :4], c2w_sc)
-
-    render_dict = {
-        "train": train_poses,
-        "val": val_poses,
-        "test": test_poses,
-        "render": render_poses,
-    }
-    render_poses = render_dict[FLAGS.render_video_set]
+    logging.info("Num poses: %d", num_poses)
+    logging.info("Splits: train - %d, val - %d, test - %d", *counts)
+    logging.info("Images: height %d, width %d, focal %.5f", *hwf)
+    logging.info("Render: height %d, width %d, focal %.5f", *r_hwf)
 
     ### Init model parameters and optimizer
     input_pts_shape = (FLAGS.config.num_rand, FLAGS.config.num_samples, 3)
@@ -189,7 +138,6 @@ def main(_):
     model_coarse, params_coarse = initialized(
         init_rng_coarse, input_pts_shape, input_views_shape, FLAGS.config.model
     )
-
     optimizer = optim.Adam()
     state = TrainState(
         step=0, optimizer_coarse=optimizer.create(params_coarse), optimizer_fine=None
@@ -209,60 +157,69 @@ def main(_):
         model_fn = (model_coarse.apply, model_fine.apply)
 
     state = checkpoints.restore_checkpoint(FLAGS.model_dir, state)
-    state_step = int(state.step)
+    step = int(state.step)
     state = jax_utils.replicate(state)
 
+    render_dict = {
+        "train": list(zip(range(train_items), train_ds)),
+        "val": list(zip(range(val_items), val_ds)),
+        "test": list(zip(range(test_items), test_ds)),
+        "render": list(zip(range(num_poses), render_ds)),
+    }
+    render_poses = render_dict[FLAGS.render_video_set]
+
+    def render_fn(state, rays):
+        step_fn = functools.partial(eval_step, model_fn, FLAGS.config, near, far, state)
+        return lax.map(step_fn, rays)
+
     p_eval_step = jax.pmap(
-        functools.partial(eval_step, model_fn, FLAGS.config),
+        render_fn,
         axis_name="batch",
+        # in_axes=(0, 0, None),
+        # donate_argnums=(0, 1))
     )
-    eval_fn = lambda x: p_eval_step(state, x)[0]["rgb"]
 
     if FLAGS.render_video:
-        rays_render = lax.map(lambda x: prep_rays(r_hwf, x), render_poses)
-        render_shape = [-1, n_devices, r_hwf[1], rays_render.shape[-1]]
-        rays_render = jnp.reshape(rays_render, render_shape)
-        logging.info("Render rays shape: %s", rays_render.shape)
+        rgb_list = []
+        disp_list = []
+        losses = []
+        for _, inputs in tqdm(render_poses, desc="Rays render"):
+            rays, padding = prepare_render_data(inputs["rays"]._numpy())
+            preds, *_ = p_eval_step(state, rays)
+            preds = jax.tree_map(lambda x: to_np(x, r_hwf, padding), preds)
+            rgb_list.append(preds["rgb"])
+            disp_list.append(preds["disp"])
 
-        logging.info("Rendering video at step %d", state_step)
-        t = time.time()
-        preds, *_ = lax.map(lambda x: p_eval_step(state, x), rays_render)
-        gen_video(preds["rgb"], "rgb", r_hwf, state_step)
-        gen_video(
-            preds["disp"] / jnp.max(preds["disp"]), "disp", r_hwf, state_step, ch=1
-        )
-        if FLAGS.render_video_set == "test" and FLAGS.config.render_factor == 0:
-            loss = jnp.mean((preds["rgb"].reshape(test_imgs.shape) - test_imgs) ** 2.0)
-            logging.info("test/loss %.5f", loss)
-            logging.info("test/psnr %.5f", psnr_fn(loss))
+            if FLAGS.config.render_factor == 1 and FLAGS.render_video_set != "render":
+                loss = np.mean((preds["rgb"] - inputs["image"]) ** 2.0)
+                losses.append(loss)
 
-        if FLAGS.config.use_viewdirs:
-            logging.info("Rendering video for view directions at step %d", state_step)
-            rays_render_vdirs = lax.map(
-                lambda x: prep_rays(r_hwf, x, render_poses[0]), render_poses
-            ).reshape(render_shape)
-            preds = lax.map(eval_fn, rays_render_vdirs)
-            gen_video(preds, "rgb_still", r_hwf, state_step)
-        logging.info("Video rendering done in %ds", time.time() - t)
+        if FLAGS.config.render_factor == 1 and FLAGS.render_video_set != "render":
+            loss = np.mean(losses)
+            logging.info("Loss %.5f", loss)
+            logging.info("PSNR %.5f", psnr_fn(loss))
+        gen_video(np.stack(rgb_list), "rgb", r_hwf, step)
+        disp = np.stack(disp_list)
+        gen_video(disp_post(disp, FLAGS.config), "disp", r_hwf, step, ch=1)
 
     if FLAGS.render_testset:
-        test_rays = lax.map(lambda pose: prep_rays(r_hwf, pose), test_poses)
-        test_rays = jnp.reshape(
-            test_rays, [-1, n_devices, r_hwf[1], test_rays.shape[-1]]
-        )
-        logging.info("Test rays shape: %s", test_rays.shape)
-        logging.info("Rendering test set at step %d", state_step)
-        preds = lax.map(eval_fn, test_rays)
-        save_test_imgs(preds, r_hwf, state_step)
+        test_losses = []
+        for idx, inputs in tqdm(zip(range(test_items), test_ds), desc="Test render"):
+            rays, padding = prepare_render_data(inputs["rays"]._numpy())
+            preds, *_ = p_eval_step(state, rays)
+            preds = jax.tree_map(lambda x: to_np(x, r_hwf, padding), preds)
+            save_test_imgs(preds["rgb"], r_hwf, step, idx)
 
-        if FLAGS.config.render_factor == 0:
-            loss = jnp.mean((preds.reshape(test_imgs.shape) - test_imgs) ** 2.0)
-            logging.info("test/loss %.5f", loss)
-            logging.info("test/psnr %.5f", psnr_fn(loss))
+            if FLAGS.config.render_factor == 1:
+                loss = np.mean((preds["rgb"] - inputs["image"]) ** 2.0)
+                test_losses.append(loss)
+        if FLAGS.config.render_factor == 1:
+            loss = np.mean(test_losses)
+            logging.info("Loss %.5f", loss)
+            logging.info("PSNR %.5f", psnr_fn(loss))
 
 
 if __name__ == "__main__":
-    flags.mark_flag_as_required("model_dir")
-    flags.mark_flag_as_required("data_dir")
+    flags.mark_flags_as_required(["data_dir", "config", "model_dir"])
     logging.set_verbosity(logging.INFO)
     app.run(main)


### PR DESCRIPTION
Usage of `tf.data` allows queue based reading for large datasets and reproducible runs. Deterministic data is based on code in `clu` ([google/CommonLoopUtils](https://github.com/google/CommonLoopUtils/blob/master/clu/deterministic_data.py)), and adapted for non-tfds datasets.

Input pipeline is a bit verbose overall, but is performant and allows using both batching and non-batching + `precrop_iters` (albeit slightly slower in the latter case).

Some default parameters have been changed for better flexibility, which makes it deviate from the initial plan to follow original implementation, but whatever.